### PR TITLE
Add note about deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://travis-ci.org/NYPL/cancel-request-result-consumer.svg?branch=master)](https://travis-ci.org/NYPL/cancel-request-result-consumer) [![Coverage Status](https://coveralls.io/repos/github/NYPL/cancel-request-result-consumer/badge.svg?branch=master)](https://coveralls.io/github/NYPL/cancel-request-result-consumer?branch=master)
 
-# NYPL Cancel Request Result Consumer
+# NYPL Cancel Request Result Consumer (DEPRECATED)
+
+Note: This lambda has been deprecated in the latest ["Cancel Architecture"](https://docs.google.com/presentation/d/1uIDmpsKTx-ZJRmUw8Ifspf1gkKBL9sWjVWIR5-b_wag/edit#slide=id.g1f78577fe0_2_0).
 
 This package is intended to be used as a Lambda-based Node.js/PHP Listener to listen to a Kinesis Stream. 
 


### PR DESCRIPTION
This lambda appears to be deprecated in the latest cancel request workflow. Although the lambda remains deployed and listening on the CancelRequestResult stream, the [CancelRequestConsumer](https://github.com/NYPL/cancel-request-consumer) no longer writes to CancelRequestResult (although it retains the `CANCEL_REQUEST_RESULT_STREAM_NAME` config param, suggesting it does).

Long term we should delete the deployed lambda and CancelRequestResult kinesis stream to reduce confusion. Perhaps we can also delete/"archive" this repo?